### PR TITLE
PJL-2986: Create repo if it does not exist

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,9 +13,14 @@ node {
         stepsForParallel["Postgres ${version}"] = {
             stage("Postgres ${version}"){
                 def ver = "${version}".replace(".", "")
+                // Pull the latest image so we have a record of the sha
                 sh "docker pull 723151894364.dkr.ecr.us-east-1.amazonaws.com/postgres${ver}:latest || true"
+
                 sh "docker build -t '723151894364.dkr.ecr.us-east-1.amazonaws.com/postgres${ver}' ${version}/"
                 if (env.BRANCH_NAME == 'master') {
+                    //# Try to create the repository so the push doesn't fail
+                    sh "aws ecr create-repository --repository-name postgres${ver} || true"
+
                     sh "docker push 723151894364.dkr.ecr.us-east-1.amazonaws.com/postgres${ver}:latest"
                 }
             }


### PR DESCRIPTION
Unconditionally create the docker repo so when we introduce a new image, it can be successfully pushed.

 JIRA Tickets | 
 --------------| 
 [PJL-2986](https://jira.autodesk.com/browse/PJL-2986)|
